### PR TITLE
fix: split lock/burn tx confirmStatus type

### DIFF
--- a/offchain-modules/packages/app-rpc-server/src/handler.ts
+++ b/offchain-modules/packages/app-rpc-server/src/handler.ts
@@ -453,6 +453,7 @@ function transferDbRecordToResponse(
 ): TransactionSummaryWithStatus {
   let bridgeTxRecord: TransactionSummary;
   if ('lock_hash' in record) {
+    const confirmStatus = record.lock_confirm_status === 'confirmed' ? 'confirmed' : record.lock_confirm_number;
     bridgeTxRecord = {
       txSummary: {
         fromAsset: {
@@ -470,7 +471,7 @@ function transferDbRecordToResponse(
         fromTransaction: {
           txId: record.lock_hash,
           timestamp: record.lock_time,
-          confirmStatus: record.lock_confirm_status,
+          confirmStatus: confirmStatus,
         },
       },
     };
@@ -478,6 +479,7 @@ function transferDbRecordToResponse(
       bridgeTxRecord.txSummary.toTransaction = { txId: record.mint_hash, timestamp: record.mint_time };
     }
   } else if ('burn_hash' in record) {
+    const confirmStatus = record.burn_confirm_status === 'confirmed' ? 'confirmed' : record.burn_confirm_number;
     bridgeTxRecord = {
       txSummary: {
         fromAsset: {
@@ -495,7 +497,7 @@ function transferDbRecordToResponse(
         fromTransaction: {
           txId: record.burn_hash,
           timestamp: record.burn_time,
-          confirmStatus: record.burn_confirm_status,
+          confirmStatus: confirmStatus,
         },
       },
     };

--- a/offchain-modules/packages/x/src/db/ckb.ts
+++ b/offchain-modules/packages/x/src/db/ckb.ts
@@ -113,7 +113,7 @@ export class CkbDb {
       .getRepository(CkbBurn)
       .createQueryBuilder()
       .select()
-      .where('confirm_status != "confirmed"')
+      .where('confirm_status = "unconfirmed"')
       .limit(limit)
       .getMany();
   }
@@ -135,7 +135,7 @@ export class CkbDb {
         .getRepository(CkbBurn)
         .createQueryBuilder()
         .update()
-        .set({ confirmStatus: record.confirmedNumber })
+        .set({ confirmNumber: record.confirmedNumber })
         .where('tx_hash = :txHash', { txHash: record.txHash })
         .execute();
       updataResults.push(result);

--- a/offchain-modules/packages/x/src/db/entity/CkbBurn.ts
+++ b/offchain-modules/packages/x/src/db/entity/CkbBurn.ts
@@ -29,7 +29,10 @@ export class CkbBurn {
   @Column()
   blockNumber: number;
 
-  @Column({ default: 0 })
+  @Column({ default: 'unconfirmed' })
+  confirmNumber: number;
+
+  @Column({ default: 'unconfirmed' })
   confirmStatus: TxConfirmStatus;
 
   @CreateDateColumn()

--- a/offchain-modules/packages/x/src/db/entity/CkbBurn.ts
+++ b/offchain-modules/packages/x/src/db/entity/CkbBurn.ts
@@ -29,7 +29,7 @@ export class CkbBurn {
   @Column()
   blockNumber: number;
 
-  @Column({ default: 'unconfirmed' })
+  @Column({ default: 0 })
   confirmNumber: number;
 
   @Column({ default: 'unconfirmed' })

--- a/offchain-modules/packages/x/src/db/entity/EthLock.ts
+++ b/offchain-modules/packages/x/src/db/entity/EthLock.ts
@@ -1,6 +1,6 @@
 import { Column, CreateDateColumn, Entity, Index, PrimaryColumn, UpdateDateColumn } from 'typeorm';
 
-export type TxConfirmStatus = number | 'confirmed';
+export type TxConfirmStatus = 'unconfirmed' | 'confirmed';
 
 @Entity()
 export class EthLock {
@@ -36,6 +36,9 @@ export class EthLock {
   blockHash: string;
 
   @Column({ default: 0 })
+  confirmNumber: number;
+
+  @Column({ default: 'unconfirmed' })
   confirmStatus: TxConfirmStatus;
 
   @CreateDateColumn()

--- a/offchain-modules/packages/x/src/db/eth.ts
+++ b/offchain-modules/packages/x/src/db/eth.ts
@@ -46,7 +46,7 @@ export class EthDb implements IQuery {
     return this.ethLockRepository
       .createQueryBuilder()
       .select()
-      .where('confirm_status != "confirmed"')
+      .where('confirm_status = "unconfirmed"')
       .limit(limit)
       .getMany();
   }
@@ -66,7 +66,7 @@ export class EthDb implements IQuery {
       const result = await this.ethLockRepository
         .createQueryBuilder()
         .update()
-        .set({ confirmStatus: record.confirmedNumber })
+        .set({ confirmNumber: record.confirmedNumber })
         .where('tx_hash = :txHash', { txHash: record.txHash })
         .execute();
       updataResults.push(result);
@@ -100,6 +100,7 @@ export class EthDb implements IQuery {
         eth.tx_hash as lock_hash,
         ckb.mint_hash as mint_hash,
         eth.updated_at as lock_time, 
+        eth.confirm_number as lock_confirm_number,
         eth.confirm_status as lock_confirm_status,
         ckb.updated_at as mint_time, 
         ckb.status as status,
@@ -130,6 +131,7 @@ export class EthDb implements IQuery {
         eth.eth_tx_hash as unlock_hash,
         eth.updated_at as unlock_time, 
         ckb.updated_at as burn_time, 
+        ckb.confirm_number as burn_confirm_number,
         ckb.confirm_status as burn_confirm_status,
         eth.status as status,
         ckb.asset as asset,
@@ -154,6 +156,7 @@ export class EthDb implements IQuery {
         eth.tx_hash as lock_hash,
         ckb.mint_hash as mint_hash,
         eth.updated_at as lock_time, 
+        eth.confirm_number as lock_confirm_number,
         eth.confirm_status as lock_confirm_status,
         ckb.updated_at as mint_time, 
         ckb.status as status,
@@ -184,6 +187,7 @@ export class EthDb implements IQuery {
         eth.eth_tx_hash as unlock_hash,
         eth.updated_at as unlock_time, 
         ckb.updated_at as burn_time, 
+        ckb.confirm_number as burn_confirm_number,
         ckb.confirm_status as burn_confirm_status,
         eth.status as status,
         ckb.asset as asset,

--- a/offchain-modules/packages/x/src/db/model.ts
+++ b/offchain-modules/packages/x/src/db/model.ts
@@ -186,6 +186,7 @@ export interface LockRecord {
   lock_hash: string;
   mint_hash: string;
   lock_time: number;
+  lock_confirm_number: number;
   lock_confirm_status: TxConfirmStatus;
   mint_time: number;
   status: dbTxStatus;
@@ -201,6 +202,7 @@ export interface UnlockRecord {
   burn_hash: string;
   unlock_hash: string;
   burn_time: number;
+  burn_confirm_number: number;
   burn_confirm_status: TxConfirmStatus;
   unlock_time: number;
   status: dbTxStatus;

--- a/offchain-modules/packages/x/src/handlers/ckb.ts
+++ b/offchain-modules/packages/x/src/handlers/ckb.ts
@@ -243,7 +243,7 @@ export class CkbHandler {
             bridgeFee: new EthAsset(asset).getBridgeFee('out'),
             recipientAddress: uint8ArrayToString(new Uint8Array(v.cellData.getRecipientAddress().raw())),
             blockNumber: latestHeight,
-            confirmStatus: 0,
+            confirmStatus: 'unconfirmed',
           };
           break;
         }


### PR DESCRIPTION
- split `confirmStatus: number | 'confirmed'` to `confirmStatus: 'unconfirmed' | 'confirmed'` and `confirmNumber: number`