### PR TITLE
feat: added keystore into ForceBridgeCore

### DIFF
--- a/offchain-modules/.eslintrc.js
+++ b/offchain-modules/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  root: true,
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
@@ -7,7 +8,11 @@ module.exports = {
     'plugin:import/typescript',
   ],
   env: { jest: true, node: true },
-  plugins: ['@typescript-eslint', 'import', 'prettier'],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ['./tsconfig.json', './packages/*/tsconfig.json'],
+  },
+  plugins: ['@typescript-eslint', 'import', 'prettier', 'deprecation'],
   rules: {
     '@typescript-eslint/member-ordering': 'warn',
     '@typescript-eslint/no-explicit-any': 'warn',
@@ -18,5 +23,6 @@ module.exports = {
     'import/order': ['warn', { alphabetize: { order: 'asc' } }],
     'no-console': 'warn',
     'no-constant-condition': 'warn',
+    'deprecation/deprecation': 'warn'
   },
 };

--- a/offchain-modules/.eslintrc.next.js
+++ b/offchain-modules/.eslintrc.next.js
@@ -1,17 +1,11 @@
 module.exports = {
   extends: '.eslintrc.js',
-  plugins: ['deprecation'],
-  parserOptions: {
-    tsconfigRootDir: __dirname,
-    project: ['./tsconfig.json', './packages/*/tsconfig.json'],
-  },
   rules: {
     '@typescript-eslint/no-explicit-any': 'error',
     '@typescript-eslint/no-require-imports': 'error',
     '@typescript-eslint/explicit-module-boundary-types': 'error',
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
     '@typescript-eslint/no-floating-promises': ['error'],
-    'import/order': ['error', { alphabetize: { order: 'asc' } }],
-    'deprecation/deprecation': 'error',
+    'import/order': ['error', { alphabetize: { order: 'asc' } }]
   },
 };

--- a/offchain-modules/packages/x/src/config.ts
+++ b/offchain-modules/packages/x/src/config.ts
@@ -46,11 +46,11 @@ export interface CkbConfig {
   ckbRpcUrl: string;
   ckbIndexerUrl: string;
   /**
-   * @deprecated migrate to {@link KeyStore}
+   * @deprecated migrate to {@link ForceBridgeCore}.keystore.get('ckb')
    */
   fromPrivateKey: string;
   /**
-   * @deprecated migrate to {@link KeyStore}
+   * @deprecated migrate to {@link ForceBridgeCore}.keystore.get('ckb-multisig') or {@link ForceBridgeCore}.keystore.get('ckb-multisig-n')
    */
   multiSignKeys: MultiSignKey[];
   multiSignHosts: MultiSignHost[];
@@ -70,11 +70,11 @@ export interface EthConfig {
   rpcUrl: string;
   contractAddress: string;
   /**
-   * @deprecated migrate to {@link KeyStore}
+   * @deprecated migrate to {@link KeyStore}.keystore.get('eth')
    */
   privateKey: string;
   /**
-   * @deprecated migrate to {@link KeyStore}
+   * @deprecated migrate to {@link KeyStore}.keystore.get('eth-multisig') or {@link ForceBridgeCore}.keystore.get('eth-multisig-n')
    */
   multiSignKeys: MultiSignKey[];
   multiSignAddresses: string[];

--- a/offchain-modules/packages/x/src/core.ts
+++ b/offchain-modules/packages/x/src/core.ts
@@ -47,6 +47,7 @@ export class ForceBridgeCore {
   private static _config: Config;
   private static _ckb: CKB;
   private static _ckbIndexer: CkbIndexer;
+  private static _keystore: KeyStore;
 
   static get config(): Config {
     asserts(ForceBridgeCore._config, 'ForceBridgeCore is not init yet');
@@ -63,11 +64,18 @@ export class ForceBridgeCore {
     return ForceBridgeCore._ckbIndexer;
   }
 
+  static get keystore(): KeyStore {
+    asserts(ForceBridgeCore._keystore, 'ForceBridgeCore is not init yet');
+    return ForceBridgeCore._keystore;
+  }
+
   /**
    * @deprecated migrate to {@link bootstrap}
-   * @param config
-   * @returns
    */
+  constructor() {
+    // TODO make constructor to be private
+  }
+
   async init(
     config: Config,
     keystore: KeyStore<KeyID> = bootstrapKeyStore('./keystore.json'),
@@ -80,6 +88,7 @@ export class ForceBridgeCore {
     ForceBridgeCore._config = config;
     ForceBridgeCore._ckb = new CKB(config.ckb.ckbRpcUrl);
     ForceBridgeCore._ckbIndexer = new CkbIndexer(config.ckb.ckbRpcUrl, config.ckb.ckbIndexerUrl);
+    ForceBridgeCore._keystore = keystore;
 
     // TODO remove private key in ForceBridgeCore
     ForceBridgeCore.config.ckb.fromPrivateKey = keystore.getDecryptedByKeyID('ckb');

--- a/offchain-modules/packages/x/src/core.ts
+++ b/offchain-modules/packages/x/src/core.ts
@@ -91,8 +91,11 @@ export class ForceBridgeCore {
     ForceBridgeCore._keystore = keystore;
 
     // TODO remove private key in ForceBridgeCore
-    ForceBridgeCore.config.ckb.fromPrivateKey = keystore.getDecryptedByKeyID('ckb');
-    ForceBridgeCore.config.eth.privateKey = keystore.getDecryptedByKeyID('eth');
+    keystore.listKeyIDs().forEach((id) => {
+      if (id === 'ckb') ForceBridgeCore.config.ckb.fromPrivateKey = keystore.getDecryptedByKeyID('ckb');
+      if (id === 'eth') ForceBridgeCore.config.eth.privateKey = keystore.getDecryptedByKeyID('eth');
+    });
+
     return this;
   }
 }


### PR DESCRIPTION
- update deprecated API migration guide in deprecated info
- lint deprecated API as `warn` instead of `error`
- recommend to use `bootstrap` instead of `new ForceBridgeCore()`