### PR TITLE
feat: add sigserver status

### DIFF
--- a/offchain-modules/packages/app-multisign-server/src/status.ts
+++ b/offchain-modules/packages/app-multisign-server/src/status.ts
@@ -1,0 +1,27 @@
+import { ForceBridgeCore } from '@force-bridge/x/dist/core';
+import { privateKeyToCkbAddress, privateKeyToCkbPubkeyHash, privateKeyToEthAddress } from '@force-bridge/x/dist/utils';
+import * as lodash from 'lodash';
+import { SigResponse, SigServer } from './sigServer';
+
+export async function serverStatus(): Promise<SigResponse> {
+  const [latestCkbHeight, latestCkbBlockHash] = lodash.split(await SigServer.kvDb.get('lastHandleCkbBlock'), ',', 2);
+  const [latestEthHeight, latestEthBlockHash] = lodash.split(await SigServer.kvDb.get('lastHandleEthBlock'), ',', 2);
+  const data = {
+    addressConfig: {
+      ethAddress: privateKeyToEthAddress(ForceBridgeCore.config.eth.privateKey),
+      ckbPubkeyHash: privateKeyToCkbPubkeyHash(ForceBridgeCore.config.ckb.privateKey),
+      ckbAddress: privateKeyToCkbAddress(ForceBridgeCore.config.ckb.privateKey),
+    },
+    latestChainStatus: {
+      ckb: {
+        latestCkbHeight,
+        latestCkbBlockHash,
+      },
+      eth: {
+        latestEthHeight,
+        latestEthBlockHash,
+      },
+    },
+  };
+  return SigResponse.fromData(data);
+}


### PR DESCRIPTION
example

```
$ http http://127.0.0.1:8000/force-bridge/sign-server/api/v1 <<< '{ "id": 0, "jsonrpc": "2.0", "method": "status" }'

{
    "id": 0,
    "jsonrpc": "2.0",
    "result": {
        "addressConfig": {
            "ckbAddress": "ckt1qyqx9424gr3p237a36lt8veh50gaavc27jpqmhrdum",
            "ckbPubkeyHash": "0x62d55540e21547dd8ebeb3b337a3d1deb30af482",
            "ethAddress": "0x994B430359BEDCfeb73EB90Fb39416A7dE1F1640"
        },
        "latestChainStatus": {
            "ckb": {
                "latestCkbBlockHash": "0x95e1f7331c7a5a41ef24a8fbecc2ff10d2319fa678479d2345c8b8ebc04f9868",
                "latestCkbHeight": "1417"
            },
            "eth": {
                "latestEthBlockHash": "0xea3470c3ba5f26c4d049e9796940bb973258992d149e0f708774bac1b3182b7b",
                "latestEthHeight": "1180"
            }
        }
    }
}

```